### PR TITLE
Support aggregate_failures (rspec 3.3 feature)

### DIFF
--- a/lib/rspec/power_assert.rb
+++ b/lib/rspec/power_assert.rb
@@ -75,8 +75,15 @@ module RSpec
         end
       else
         ex = RSpec::Expectations::ExpectationNotMetError.new(msg)
-        ex.set_backtrace(location)
-        raise ex
+
+        if defined?(RSpec::Support) && RSpec::Support.respond_to?(:notify_failure)
+          # for RSpec 3.3+
+          RSpec::Support.notify_failure(ex)
+        else
+          # for RSpec 2, 3.0, 3.1, 3.2
+          ex.set_backtrace(location)
+          raise ex
+        end
       end
     end
 

--- a/spec/rspec/power_assert_spec.rb
+++ b/spec/rspec/power_assert_spec.rb
@@ -67,6 +67,38 @@ describe Rspec::PowerAssert do
       it_is_asserted_by "succ each element" do
         subject.map(&:succ) == ["b", "c", "e"] + @array
       end
+
+      context "When use aggregate_failures" do
+        before do
+          unless respond_to?(:aggregate_failures)
+            pending_message = "This test can run only on RSpec 3.3+"
+
+            if respond_to?(:skip)
+              # for RSpec 3
+              skip pending_message
+            else
+              # for RSpec 2
+              pending pending_message
+            end
+          end
+        end
+
+        it "should be called expect with 3 times" do
+          aggregate_failures do
+            expect(subject.map(&:upcase)).to eq %w(a b c)
+            expect(subject.map(&:upcase)).to eq %w(A B C)
+            expect(subject.map(&:upcase)).to eq %w(A B C D)
+          end
+        end
+
+        it "should be called is_asserted_by with 3 times" do
+          aggregate_failures do
+            is_asserted_by { subject.map(&:upcase) == %w(a b c) }
+            is_asserted_by { subject.map(&:upcase) == %w(A B C) }
+            is_asserted_by { subject.map(&:upcase) == %w(A B C D) }
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
I support  `aggregate_failures`

# Before
```sh
$ bundle exec rspec  -- spec/rspec/power_assert_spec.rb:71
Run options: include {:locations=>{"./spec/rspec/power_assert_spec.rb"=>[71]}}

Rspec::PowerAssert
  Array
    #map
      When use aggregate_failures
        should be called expect with 3 times (FAILED - 1)
        should be called is_asserted_by with 3 times (FAILED - 2)

Failures:

  1) Rspec::PowerAssert Array#map When use aggregate_failures should be called expect with 3 times
     Got 2 failures from failure aggregation block.
     # ./spec/rspec/power_assert_spec.rb:87:in `block (5 levels) in <top (required)>'

     1.1) Failure/Error: expect(subject.map(&:upcase)).to eq %w(a b c)

            expected: ["a", "b", "c"]
                 got: ["A", "B", "C"]

            (compared using ==)
          # ./spec/rspec/power_assert_spec.rb:88:in `block (6 levels) in <top (required)>'

     1.2) Failure/Error: expect(subject.map(&:upcase)).to eq %w(A B C D)

            expected: ["A", "B", "C", "D"]
                 got: ["A", "B", "C"]

            (compared using ==)
          # ./spec/rspec/power_assert_spec.rb:90:in `block (6 levels) in <top (required)>'

  2) Rspec::PowerAssert Array#map When use aggregate_failures should be called is_asserted_by with 3 times
     Failure/Error: is_asserted_by { subject.map(&:upcase) == %w(a b c) }
                   is_asserted_by { subject.map(&:upcase) == %w(a b c) }
                                    |       |             |
                                    |       |             false
                                    |       ["A", "B", "C"]
                                    ["a", "b", "c"]
     # ./spec/rspec/power_assert_spec.rb:96

Finished in 0.02684 seconds (files took 0.18396 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/rspec/power_assert_spec.rb:86 # Rspec::PowerAssert Array#map When use aggregate_failures should called expect with 3 times
rspec ./spec/rspec/power_assert_spec.rb:94 # Rspec::PowerAssert Array#map When use aggregate_failures should called is_asserted_by with 3 times
```

all expectations in `aggregate_failures` should be called, but not called after 1st failure :innocent:

# After
```sh
$ bundle exec rspec  -- spec/rspec/power_assert_spec.rb:71
Run options: include {:locations=>{"./spec/rspec/power_assert_spec.rb"=>[71]}}

Rspec::PowerAssert
  Array
    #map
      When use aggregate_failures
        should be called expect with 3 times (FAILED - 1)
        should be called is_asserted_by with 3 times (FAILED - 2)

Failures:

  1) Rspec::PowerAssert Array#map When use aggregate_failures should be called expect with 3 times
     Got 2 failures from failure aggregation block.
     # ./spec/rspec/power_assert_spec.rb:73:in `block (5 levels) in <top (required)>'

     1.1) Failure/Error: expect(subject.map(&:upcase)).to eq %w(a b c)

            expected: ["a", "b", "c"]
                 got: ["A", "B", "C"]

            (compared using ==)
          # ./spec/rspec/power_assert_spec.rb:74:in `block (6 levels) in <top (required)>'

     1.2) Failure/Error: expect(subject.map(&:upcase)).to eq %w(A B C D)

            expected: ["A", "B", "C", "D"]
                 got: ["A", "B", "C"]

            (compared using ==)
          # ./spec/rspec/power_assert_spec.rb:76:in `block (6 levels) in <top (required)>'

  2) Rspec::PowerAssert Array#map When use aggregate_failures should be called be is_asserted_by with 3 times
     Got 2 failures from failure aggregation block.
     # ./spec/rspec/power_assert_spec.rb:81:in `block (5 levels) in <top (required)>'

     2.1) Failure/Error: is_asserted_by { subject.map(&:upcase) == %w(a b c) }
                        is_asserted_by { subject.map(&:upcase) == %w(a b c) }
                                         |       |             |
                                         |       |             false
                                         |       ["A", "B", "C"]
                                         ["a", "b", "c"]
          # ./lib/rspec/power_assert.rb:81:in `handle_result_and_message'
          # ./lib/rspec/power_assert.rb:50:in `is_asserted_by'
          # ./spec/rspec/power_assert_spec.rb:82:in `block (6 levels) in <top (required)>'

     2.2) Failure/Error: is_asserted_by { subject.map(&:upcase) == %w(A B C D) }
                        is_asserted_by { subject.map(&:upcase) == %w(A B C D) }
                                         |       |             |
                                         |       |             false
                                         |       ["A", "B", "C"]
                                         ["a", "b", "c"]
          # ./lib/rspec/power_assert.rb:81:in `handle_result_and_message'
          # ./lib/rspec/power_assert.rb:50:in `is_asserted_by'
          # ./spec/rspec/power_assert_spec.rb:84:in `block (6 levels) in <top (required)>'

Finished in 0.02937 seconds (files took 0.19416 seconds to load)
2 examples, 2 failures
```

All expectations are called! :muscle:

# Checked versions
* rspec 2.14.1
* rspec 3.2.0
* rspec 3.3.0
