### PR TITLE
Follow up to power_assert 1.0.0

### DIFF
--- a/lib/rspec/power_assert.rb
+++ b/lib/rspec/power_assert.rb
@@ -3,22 +3,7 @@ require "rspec/core"
 require "power_assert"
 
 module PowerAssert
-  class << self
-    def rspec_start(assertion_proc, assertion_method: nil, source_binding: TOPLEVEL_BINDING)
-      yield RSpecContext.new(assertion_proc, assertion_method, source_binding)
-    end
-  end
-
-  class RSpecContext < Context
-    # hack for context changing
-    def do_yield
-      @trace.enable do
-        @base_caller_length = caller_locations.length + 2
-        yield
-      end
-    end
-  end
-  private_constant :RSpecContext
+  IGNORED_LIB_DIRS[Rspec::PowerAssert]  = __dir__
 end
 
 module RSpec
@@ -56,7 +41,7 @@ module RSpec
       # hack for context changing
       pr = -> { self.instance_exec(&blk) }
 
-      result, msg = ::PowerAssert.rspec_start(pr, assertion_method: method_name) do |tp|
+      result, msg = ::PowerAssert.start(pr, assertion_method: method_name) do |tp|
         [tp.yield, tp.message_proc.call]
       end
 

--- a/rspec-power_assert.gemspec
+++ b/rspec-power_assert.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "power_assert", "~> 0.3.0"
+  spec.add_runtime_dependency "power_assert", "~> 1.0.0"
   spec.add_runtime_dependency "rspec", ">= 2.14"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
To combine with byebug, power_assert 1.0.0 breaks compatibility of internal API.
This PR follows up to it.
