### PR TITLE
Follow up to power_assert 1.1.0

### DIFF
--- a/lib/rspec/power_assert.rb
+++ b/lib/rspec/power_assert.rb
@@ -3,7 +3,7 @@ require "rspec/core"
 require "power_assert"
 
 module PowerAssert
-  IGNORED_LIB_DIRS[RSpec::PowerAssert]  = __dir__
+  INTERNAL_LIB_DIRS[RSpec::PowerAssert]  = __dir__
 end
 
 module RSpec

--- a/rspec-power_assert.gemspec
+++ b/rspec-power_assert.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "power_assert", "~> 1.0.0"
+  spec.add_runtime_dependency "power_assert", "~> 1.1.0"
   spec.add_runtime_dependency "rspec", ">= 2.14"
 
   spec.add_development_dependency "bundler", "~> 1.7"


### PR DESCRIPTION
From power_assert 1.1.0, ```PowerAssert::IGNORED_LIB_DIRS``` is obsolete.